### PR TITLE
Update

### DIFF
--- a/PCloudSDKSwift/Source/URLSessionTaskBuilder.swift
+++ b/PCloudSDKSwift/Source/URLSessionTaskBuilder.swift
@@ -79,7 +79,7 @@ public struct URLSessionTaskBuilder {
 		
 		let path = resourceAddress.path
 		
-		let cookies = cookiesDictionary.flatMap { name, value in
+		let cookies = cookiesDictionary.compactMap { name, value in
 			HTTPCookie(properties: [.name: name, .value: value, .domain: host, .path: path])
 		}
 		


### PR DESCRIPTION
flatMap is deprecated, according to swift compiler, using the last version of xcode9.3