### PR TITLE
Fixed SPM warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "PCloudSDKSwift", targets: ["PCloudSDKSwift"]),
     ],
     targets: [
-		.target(name: "PCloudSDKSwift", dependencies: [], path: "PCloudSDKSwift/Source", exclude: ["macOS"]),
-		.testTarget(name: "PCloudSDKSwiftTests", dependencies: ["PCloudSDKSwift"], path: "PCloudSDKSwift/Tests"),
+		.target(name: "PCloudSDKSwift", dependencies: [], path: "PCloudSDKSwift/Source", exclude: ["macOS", "iOS/Info.plist"]),
+		.testTarget(name: "PCloudSDKSwiftTests", dependencies: ["PCloudSDKSwift"], path: "PCloudSDKSwift/Tests", exclude: ["Info.plist"]),
     ]
 )


### PR DESCRIPTION
When adding this library as a dependency via SPM, there is a warning like:

```
found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
```

The culprit are the `Info.plist` files, which I've then excluded.